### PR TITLE
Fix: update yarn.lock, include pegjs

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2482,6 +2482,10 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+pegjs@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/pegjs/-/pegjs-0.10.0.tgz#cf8bafae6eddff4b5a7efb185269eaaf4610ddbd"
+
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"


### PR DESCRIPTION
`pegjs` wasn't in the lockfile. Perhaps you forgot to commit the change?