### PR TITLE
chore: bump esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "docs": "jsdoc2md --template docs/template/functions.hbs src/functions/*.js > docs/functions.md",
     "lint": "eslint src/*.js src/**/*.js test/*.js test/**/*.js",
     "lint:fix": "eslint --fix src/*.js src/**/*.js test/*.js test/**/*.js",
-    "test": "mocha --require @std/esm --colors ./test/*.spec.js ./test/**/*.spec.js",
-    "test:watch": "mocha --require @std/esm --colors -w ./test/*.spec.js ./test/**/*.spec.js",
+    "test": "mocha --require esm --colors ./test/*.spec.js ./test/**/*.spec.js",
+    "test:watch": "mocha --require esm --colors -w ./test/*.spec.js ./test/**/*.spec.js",
     "version": "npm run docs",
     "pretest": "npm run build"
   },
@@ -39,12 +39,13 @@
     "singleQuote": true,
     "trailingComma": "es5"
   },
-  "@std/esm": "cjs",
+  "esm": {
+    "cjs": true
+  },
   "dependencies": {},
   "devDependencies": {
     "@elastic/eslint-config-kibana": "^0.15.0",
     "@elastic/eslint-import-resolver-kibana": "^2.0.0",
-    "@std/esm": "^0.25.2",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.0",
     "babel-plugin-external-helpers": "^6.22.0",
@@ -60,6 +61,7 @@
     "eslint-plugin-prefer-object-spread": "^1.2.1",
     "eslint-plugin-prettier": "^2.4.0",
     "eslint-plugin-react": "^7.1.0",
+    "esm": "^3.0.84",
     "jsdoc": "^3.5.5",
     "jsdoc-to-markdown": "^4.0.1",
     "mocha": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,11 +81,6 @@
     glob-all "^3.1.0"
     webpack "3.6.0"
 
-"@std/esm@^0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@std/esm/-/esm-0.25.2.tgz#b71e1545764f96134935fd1cb5f3785e0cb19d15"
-  integrity sha512-YvgAIsOl5gQhiln2ZZrC2gfCvav41LkDNj3RGmNM+aSPpYJuCYUgemJkz8t3T5wGSsPUsuswxZfh7RAZLHuKJQ==
-
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -2173,6 +2168,11 @@ eslint-scope@^3.7.1:
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
+
+esm@^3.0.84:
+  version "3.0.84"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.0.84.tgz#bb108989f4673b32d4f62406869c28eed3815a63"
+  integrity sha512-SzSGoZc17S7P+12R9cg21Bdb7eybX25RnIeRZ80xZs+VZ3kdQKzqTp2k4hZJjR7p9l0186TTXSgrxzlMDBktlw==
 
 espree@^3.5.2:
   version "3.5.2"


### PR DESCRIPTION
Switch to `esm` instead of the deprecated `@std/esm`.